### PR TITLE
Always unpack mode specific colors

### DIFF
--- a/openrgb/utils.py
+++ b/openrgb/utils.py
@@ -279,11 +279,10 @@ class ModeData:
         if ModeFlags.HAS_SPEED not in buff[1]:
             buff[2], buff[3], buff[6] = None, None, None
         buff[8] = ModeColors(buff[8])
-        if ModeFlags.HAS_MODE_SPECIFIC_COLOR in buff[1]:
-            for i in range(buff[-1]):
-                start, color = RGBColor.unpack(data, start)
-                colors.append(color)
-        else:
+        for i in range(buff[-1]):
+            start, color = RGBColor.unpack(data, start)
+            colors.append(color)
+        if buff[-1] == 0:
             colors, buff[4], buff[5] = None, None, None
         return start, cls(index, val, *buff[:9], colors)
 


### PR DESCRIPTION
Even if the `ModeFlags.HAS_MODE_SPECIFIC_COLOR` flag isn't set the OpenRGB server might still send color data. I ran into this with the [Water Cooler](https://gitlab.com/CalcProgrammer1/OpenRGB/-/blob/master/Controllers/NZXTKrakenController/RGBController_NZXTKraken.cpp#L136) mode. The additional color will mess with `start` and eventually lead to an unpack error:
```
Traceback (most recent call last):
  File "examples/spectrum-cycle.py", line 6, in <module>
    client = OpenRGBClient()
  File "/home/martin/.local/lib/python3.8/site-packages/openrgb/orgb.py", line 235, in __init__
    self.comms.requestDeviceNum()
  File "/home/martin/.local/lib/python3.8/site-packages/openrgb/network.py", line 126, in requestDeviceNum
    self.read()
  File "/home/martin/.local/lib/python3.8/site-packages/openrgb/network.py", line 94, in read
    self.callback(device_id, packet_type, buff[0])
  File "/home/martin/.local/lib/python3.8/site-packages/openrgb/orgb.py", line 249, in _callback
    self.comms.requestDeviceData(x)
  File "/home/martin/.local/lib/python3.8/site-packages/openrgb/network.py", line 119, in requestDeviceData
    self.read()
  File "/home/martin/.local/lib/python3.8/site-packages/openrgb/network.py", line 105, in read
    self.callback(device_id, packet_type, utils.ControllerData.unpack(data))
  File "/home/martin/.local/lib/python3.8/site-packages/openrgb/utils.py", line 452, in unpack
    start, mode = ModeData.unpack(data, start, x)
  File "/home/martin/.local/lib/python3.8/site-packages/openrgb/utils.py", line 288, in unpack
    start, color = RGBColor.unpack(data, start)
  File "/home/martin/.local/lib/python3.8/site-packages/openrgb/utils.py", line 153, in unpack
    r, g, b = struct.unpack("BBBx", data[start:start + size])
struct.error: unpack requires a buffer of 4 bytes
```
I will also create a PR for OpenRGB to fix it there. Although I don't think this is necessarily something that needs to be fixed in the client it will definitely make it more robust.