### PR TITLE
FIX: deadlock in case of disconnection

### DIFF
--- a/openrgb/network.py
+++ b/openrgb/network.py
@@ -219,7 +219,7 @@ class NetworkClient:
             raise utils.OpenRGBDisconnected()
         try:
             sent = self.sock.send(data, NOSIGNAL)
-            if (sent != len(data)):
+            if sent != len(data):
                 self.stop_connection()
                 raise utils.OpenRGBDisconnected()
         except utils.CONNECTION_ERRORS as e:

--- a/openrgb/utils.py
+++ b/openrgb/utils.py
@@ -4,10 +4,11 @@ from typing import BinaryIO
 from dataclasses import dataclass
 import struct
 import colorsys
+import socket
 
 HEADER_SIZE = 16
 
-CONNECTION_ERRORS = (ConnectionResetError, BrokenPipeError, TimeoutError)
+CONNECTION_ERRORS = (ConnectionResetError, BrokenPipeError, TimeoutError, socket.timeout)
 
 
 class ModeFlags(IntFlag):


### PR DESCRIPTION
If connection to OpenRGB is lost, the next `send_header` takes the lock and it's never released -> deadlock