### PR TITLE
Fix zone parsing desync on OpenRGB 1.0rc3+ servers- #1

### DIFF
--- a/openrgb/utils.py
+++ b/openrgb/utils.py
@@ -71,13 +71,6 @@ class ZoneType(IntEnum):
     MATRIX_LOOP_Y = 5
     SEGMENTED = 6
 
-    @classmethod
-    def _missing_(cls, value):
-        member = int.__new__(cls, value)
-        member._name_ = f"UNKNOWN_{value}"
-        member._value_ = value
-        return member
-
 
 class PacketType(IntEnum):
     REQUEST_CONTROLLER_COUNT = 0
@@ -449,12 +442,12 @@ class ZoneData:
                 self.num_leds
             )
         )
-        if self.mat_height and self.mat_width:  # type: ignore
-            flat = [i if i is not None else 0xFFFFFFFF for li in self.matrix_map for i in li]  # type: ignore
+        if self.mat_height > 0 and self.mat_width > 0:  # type: ignore
+            flat = [i for li in self.matrix_map for i in li]  # type: ignore
             assert len(flat) == (self.mat_width * self.mat_height)  # type: ignore
             data += struct.pack(
-                f"=HII{len(flat)}I",
-                8 + len(flat) * 4,
+                f"HII{len(flat)}I",
+                len(flat),
                 self.mat_height,
                 self.mat_width,
                 *flat

--- a/openrgb/utils.py
+++ b/openrgb/utils.py
@@ -449,12 +449,12 @@ class ZoneData:
                 self.num_leds
             )
         )
-        if self.mat_height > 0 and self.mat_width > 0:  # type: ignore
-            flat = [i for li in self.matrix_map for i in li]  # type: ignore
+        if self.mat_height and self.mat_width:  # type: ignore
+            flat = [i if i is not None else 0xFFFFFFFF for li in self.matrix_map for i in li]  # type: ignore
             assert len(flat) == (self.mat_width * self.mat_height)  # type: ignore
             data += struct.pack(
-                f"HII{len(flat)}I",
-                len(flat),
+                f"=HII{len(flat)}I",
+                8 + len(flat) * 4,
                 self.mat_height,
                 self.mat_width,
                 *flat

--- a/openrgb/utils.py
+++ b/openrgb/utils.py
@@ -66,6 +66,17 @@ class ZoneType(IntEnum):
     SINGLE = 0
     LINEAR = 1
     MATRIX = 2
+    LINEAR_LOOP = 3
+    MATRIX_LOOP_X = 4
+    MATRIX_LOOP_Y = 5
+    SEGMENTED = 6
+
+    @classmethod
+    def _missing_(cls, value):
+        member = int.__new__(cls, value)
+        member._name_ = f"UNKNOWN_{value}"
+        member._value_ = value
+        return member
 
 
 class PacketType(IntEnum):
@@ -468,7 +479,7 @@ class ZoneData:
         leds_max = parse_var('I', data)
         num_leds = parse_var('I', data)
         matrix_zone_size = parse_var('H', data)
-        if zone_type == ZoneType.MATRIX:
+        if matrix_zone_size > 0:
             height = parse_var('I', data)
             width = parse_var('I', data)
             matrix: list[list[Optional[int]]] = [[] for x in range(height)]


### PR DESCRIPTION
Servers with SDK protocol >= 5 serialize a matrix map block for every zone, not just MATRIX zones. ZoneData.unpack only consumed it when zone_type == MATRIX, leaving the parser 8 bytes behind on LINEAR/SINGLE zones and producing garbage values (e.g. "256 is not a valid ZoneType") during device discovery.

Consume the matrix block whenever matrix_zone_size > 0, which is backward compatible since the size is 0 when no map exists. Also widen ZoneType to the current server values (LINEAR_LOOP, MATRIX_LOOP_X, MATRIX_LOOP_Y, SEGMENTED) and add a missing fallback so future types don't crash.